### PR TITLE
client modifier cidr address range support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/requests.json
 test/requests2.json
 test/*.pprof
 test/*.db
+*~

--- a/rules/clients.go
+++ b/rules/clients.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 )
 
+// set representation for $client modifiers
 type clients struct {
 	hosts []string
 	nets  ipNets
@@ -91,8 +92,8 @@ func (c *clients) contains(host string, ipStr string) bool {
 
 	ip := net.ParseIP(ipStr)
 	if ip != nil {
-		for _, net := range c.nets {
-			if net.Contains(ip) {
+		for _, subnet := range c.nets {
+			if subnet.Contains(ip) {
 				return true
 			}
 		}
@@ -102,6 +103,7 @@ func (c *clients) contains(host string, ipStr string) bool {
 }
 
 type ipNets []net.IPNet
+var _ ipNets = sort.Interface
 
 func (n ipNets) Len() int {
 	return len(n)

--- a/rules/clients.go
+++ b/rules/clients.go
@@ -80,7 +80,7 @@ func newClients(clientStrs ...string) *clients {
 	return c
 }
 
-func (c *clients) isIn(host string, ipStr string) bool {
+func (c *clients) contains(host string, ipStr string) bool {
 	if c == nil {
 		return false
 	}

--- a/rules/clients.go
+++ b/rules/clients.go
@@ -1,0 +1,141 @@
+package rules
+
+import (
+	"bytes"
+	"net"
+	"sort"
+)
+
+type clients struct {
+	hosts []string
+	nets  ipNets
+}
+
+func (c *clients) Len() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.hosts) + len(c.nets)
+}
+
+func (c *clients) Equal(other *clients) bool {
+	if c == nil {
+		return other == nil
+	}
+	if other == nil {
+		return false
+	}
+
+	if !stringArraysEquals(c.hosts, other.hosts) {
+		return false
+	}
+
+	if len(c.nets) != len(other.nets) {
+		return false
+	}
+
+	for i, subnet := range c.nets {
+		if subnet.String() != other.nets[i].String() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (c *clients) finalize() {
+	if c != nil {
+		sort.Strings(c.hosts)
+		sort.Sort(c.nets)
+	}
+}
+
+// c != nil
+func (c *clients) add(client string) {
+	_, subnet, err := net.ParseCIDR(client)
+	if err == nil {
+		c.nets = append(c.nets, *subnet)
+		return
+	}
+
+	ip := net.ParseIP(client)
+	if ip != nil {
+		mask := net.CIDRMask(32, 32)
+		if ip.To4() == nil {
+			mask = net.CIDRMask(128, 128)
+		}
+		c.nets = append(c.nets, net.IPNet{IP: ip, Mask: mask})
+		return
+	}
+
+	c.hosts = append(c.hosts, client)
+}
+
+func newClients(clientStrs ...string) *clients {
+	c := &clients{}
+	for _, clientStr := range clientStrs {
+		c.add(clientStr)
+	}
+	c.finalize()
+	return c
+}
+
+func (c *clients) isIn(host string, ipStr string) bool {
+	if c == nil {
+		return false
+	}
+
+	if findSorted(c.hosts, host) != -1 {
+		return true
+	}
+
+	ip := net.ParseIP(ipStr)
+	if ip != nil {
+		for _, net := range c.nets {
+			if net.Contains(ip) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+type ipNets []net.IPNet
+
+func (n ipNets) Len() int {
+	return len(n)
+}
+
+func (n ipNets) Less(i, j int) bool {
+	// ipv4 < ipv6
+	if n[i].IP.To4() == nil {
+		if n[j].IP.To4() != nil {
+			return false
+		}
+	} else {
+		if n[j].IP.To4() == nil {
+			return true
+		}
+	}
+
+	// bigger subnets < smaller subnets
+	iMaskSize, _ := n[i].Mask.Size()
+	jMaskSize, _ := n[j].Mask.Size()
+	if iMaskSize < jMaskSize {
+		return true
+	}
+
+	// normalized network number byte order
+	if bytes.Compare(n[i].IP.To16(), n[j].IP.To16()) == -1 {
+		return true
+	}
+
+	return false
+}
+
+func (n ipNets) Swap(i, j int) {
+	t := n[i]
+	n[i] = n[j]
+	n[j] = t
+}

--- a/rules/clients.go
+++ b/rules/clients.go
@@ -126,6 +126,8 @@ func (n ipNets) Less(i, j int) bool {
 	jMaskSize, _ := n[j].Mask.Size()
 	if iMaskSize < jMaskSize {
 		return true
+	} else if iMaskSize > jMaskSize {
+		return false
 	}
 
 	// normalized network number byte order

--- a/rules/clients.go
+++ b/rules/clients.go
@@ -103,7 +103,7 @@ func (c *clients) contains(host string, ipStr string) bool {
 }
 
 type ipNets []net.IPNet
-var _ ipNets = sort.Interface
+var _ sort.Interface = (*ipNets)(nil)
 
 func (n ipNets) Len() int {
 	return len(n)

--- a/rules/network_rule.go
+++ b/rules/network_rule.go
@@ -548,7 +548,7 @@ func (f *NetworkRule) matchClient(name string, ip string) bool {
 		return true // the rule doesn't contain $client modifier
 	}
 
-	if f.restrictedClients.isIn(name, ip) {
+	if f.restrictedClients.contains(name, ip) {
 		// the client is in the restricted set
 		return false
 	}
@@ -557,7 +557,7 @@ func (f *NetworkRule) matchClient(name string, ip string) bool {
 		// If the rule is permitted for specific client only,
 		// we should check whether our client is among
 		// permitted or not and return the result immediately
-		return f.permittedClients.isIn(name, ip)
+		return f.permittedClients.contains(name, ip)
 	}
 
 	// If we got here, permitted list is empty and the client is not among restricted


### PR DESCRIPTION
I've extended the `$client` modifier to include CIDR address ranges for IPv4 and IPv6 networks. This allows subnet structure to be used to enforce blocklist policy and thus ESSID- or VLAN-specific rules for systems like AdGuard Home. As a result, IPv6 networks are now handled better as addresses are normalized before comparison and in IPv6 networks, hosts are typically delegated /64 blocks.