### PR TITLE
Improve proxy request type detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can learn more about AdGuard filtering rules syntax from [this article](http
     * [X] Add cosmetic filters to the proxy example
     * [X] Handling cosmetic modifiers $elemhide, $generichide, $jsinject
     * [X] (!) Server certificate verification - it should pass badssl.com/dashboard/
-    * [ ] Use fetch metadata to detect the content type: https://www.w3.org/TR/fetch-metadata/
+    * [x] Use fetch metadata to detect the content type: https://www.w3.org/TR/fetch-metadata/
     * [ ] Unit tests coverage
     * [ ] Fix TODOs
     * [ ] Proxy - handle CSP (including <meta> tags with CSP)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can learn more about AdGuard filtering rules syntax from [this article](http
     * [ ] $redirect
     * [X] $badfilter
     * [ ] $badfilter (https://github.com/AdguardTeam/CoreLibs/issues/1241)
-    * [ ] $ping modifier (https://github.com/AdguardTeam/CoreLibs/issues/1258)
+    * [X] $ping modifier (https://github.com/AdguardTeam/CoreLibs/issues/1258)
 
 #### How to use
 

--- a/proxy/proxy_handlers.go
+++ b/proxy/proxy_handlers.go
@@ -54,6 +54,11 @@ func (s *Server) onResponse(sess *gomitmproxy.Session) *http.Response {
 		return nil
 	}
 
+	if sess.Request().Method == http.MethodConnect {
+		// Do nothing for CONNECT requests
+		return nil
+	}
+
 	v, ok := sess.GetProp(sessionPropKey)
 	if !ok {
 		log.Error("urlfilter: id=%s: session not found", sess.ID())

--- a/proxy/proxy_handlers.go
+++ b/proxy/proxy_handlers.go
@@ -78,7 +78,7 @@ func (s *Server) onResponse(sess *gomitmproxy.Session) *http.Response {
 		return newBlockedResponse(session, rule)
 	}
 
-	if session.Request.RequestType == rules.TypeDocument &&
+	if (session.Request.RequestType == rules.TypeDocument || session.Request.RequestType == rules.TypeSubdocument) &&
 		session.Result.GetCosmeticOption() != rules.CosmeticOptionNone {
 		err := s.filterHTML(session)
 		if err != nil {

--- a/proxy/session.go
+++ b/proxy/session.go
@@ -84,6 +84,13 @@ func assumeRequestType(req *http.Request, res *http.Response) rules.RequestType 
 		return rules.TypeWebsocket
 	}
 
+	// Check for ping requests
+	// https://html.spec.whatwg.org/multipage/links.html#the-ping-headers
+	pingHeader := req.Header.Get("Ping-To")
+	if pingHeader != "" {
+		return rules.TypePing
+	}
+
 	fetchDestHeader := req.Header.Get("Sec-Fetch-Dest")
 	requestType := assumeRequestTypeFromFetchDest(fetchDestHeader)
 	if requestType != rules.TypeOther {
@@ -188,6 +195,8 @@ func assumeRequestTypeFromMediaType(mediaType string) rules.RequestType {
 	// $json
 	case strings.Index(mediaType, "application/json") == 0:
 		return rules.TypeXmlhttprequest
+	case strings.Index(mediaType, "text/ping") == 0:
+		return rules.TypePing
 	}
 
 	return rules.TypeOther

--- a/proxy/session.go
+++ b/proxy/session.go
@@ -78,6 +78,12 @@ func (s *Session) SetResponse(res *http.Response) {
 // req -- HTTP request
 // res -- HTTP response or null if we don't know it at the moment
 func assumeRequestType(req *http.Request, res *http.Response) rules.RequestType {
+	// Check for websocket handshakes
+	upgradeHeader := req.Header.Get("Upgrade")
+	if upgradeHeader == "websocket" {
+		return rules.TypeWebsocket
+	}
+
 	fetchDestHeader := req.Header.Get("Sec-Fetch-Dest")
 	requestType := assumeRequestTypeFromFetchDest(fetchDestHeader)
 	if requestType != rules.TypeOther {

--- a/proxy/session_test.go
+++ b/proxy/session_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAssumeRequestTypeFromFetchDest(t *testing.T) {
+	assert.Equal(t, rules.TypeDocument, assumeRequestTypeFromFetchDest("document"))
+	assert.Equal(t, rules.TypeSubdocument, assumeRequestTypeFromFetchDest("iframe"))
+	assert.Equal(t, rules.TypeStylesheet, assumeRequestTypeFromFetchDest("style"))
+	assert.Equal(t, rules.TypeScript, assumeRequestTypeFromFetchDest("script"))
+	assert.Equal(t, rules.TypeMedia, assumeRequestTypeFromFetchDest("video"))
+	assert.Equal(t, rules.TypeXmlhttprequest, assumeRequestTypeFromFetchDest("empty"))
+}
+
 func TestAssumeRequestTypeFromMediaType(t *testing.T) {
 	assert.Equal(t, rules.TypeDocument, assumeRequestTypeFromMediaType("text/html"))
 	assert.Equal(t, rules.TypeDocument, assumeRequestTypeFromMediaType("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3"))

--- a/rules/network_rule.go
+++ b/rules/network_rule.go
@@ -866,6 +866,12 @@ func (f *NetworkRule) loadOption(name, value string) error {
 	case "~websocket":
 		f.setRequestType(TypeWebsocket, false)
 		return nil
+	case "ping":
+		f.setRequestType(TypePing, true)
+		return nil
+	case "~ping":
+		f.setRequestType(TypePing, false)
+		return nil
 	case "other":
 		f.setRequestType(TypeOther, true)
 		return nil

--- a/rules/network_rule_test.go
+++ b/rules/network_rule_test.go
@@ -289,6 +289,9 @@ func TestNetworkRule_ParseRequestTypeModifiers(t *testing.T) {
 	checkRequestType(t, "websocket", TypeWebsocket, true)
 	checkRequestType(t, "~websocket", TypeWebsocket, false)
 
+	checkRequestType(t, "ping", TypePing, true)
+	checkRequestType(t, "~ping", TypePing, false)
+
 	checkRequestType(t, "other", TypeOther, true)
 	checkRequestType(t, "~other", TypeOther, false)
 }

--- a/rules/request.go
+++ b/rules/request.go
@@ -37,6 +37,8 @@ const (
 	TypeFont
 	// TypeWebsocket (a websocket connection) $websocket
 	TypeWebsocket
+	// TypePing (navigator.sendBeacon() or ping attribute on links) $ping
+	TypePing
 	// TypeOther - any other request type
 	TypeOther
 )


### PR DESCRIPTION
This pull request adds support for detecting request types in the proxy by fetch metadata, specifically the "Sec-Fetch-Dest" header (https://www.w3.org/TR/fetch-metadata/#sec-fetch-dest-header).

It also adds support for detecting websocket handshakes using the "Upgrade" header.

Additionally, I've added the "$ping" request type in the rules package and tried detecting it using the "Ping-To" header (https://html.spec.whatwg.org/multipage/links.html#the-ping-headers).

I also fixed a bug where the proxy blocked http CONNECT requests because there was no corresponding check in the "onResponse" handler.