### PR TITLE
Fix lock contention due to asking for lock when reading from cache

### DIFF
--- a/filterlist/storage.go
+++ b/filterlist/storage.go
@@ -77,9 +77,9 @@ func (s *RuleStorage) NewRuleStorageScanner() *RuleStorageScanner {
 // storageIdx is the lookup index that you can get from the rule storage scanner
 func (s *RuleStorage) RetrieveRule(storageIdx int64) (rules.Rule, error) {
 	s.cacheLock.RLock()
-	defer s.cacheLock.RUnlock()
 
 	rule, ok := s.cache[storageIdx]
+	s.cacheLock.RUnlock()
 	if ok {
 		return rule, nil
 	}


### PR DESCRIPTION
Fixes: https://github.com/AdguardTeam/AdGuardHome/issues/6818

Currently we see that AdGuardHome slows down in DNS resolution over time as mentioned in the above issue. Investigating it using pprof and looking at the mutex contention (attached in the image below) you can see that it is spending over 700ms, in my case, waiting to unlock.

![profile001](https://github.com/user-attachments/assets/1e70418f-dc6c-4096-b8d6-05c6018a9e28)

This PR attempts to fix the issue in RuleStorage. Specifically, it is using a lock to read from the cache. Originally using a non-RW lock was problematic given AdGuardHome has default of 300 goroutine and most users will have a lot of concurrent DNS look up but they are all waiting on 1 lock.

This change updates the lock to be RW lock where looking up in cache is a Read lock which allows multiple readers to retrieve the lock at the same time. If the cache look up fail then it will try to grab a W lock.

I still need to test this but if someone from your side can test this it would be good because my set it is very complicated to run forked code.

Thanks