### PR TITLE
rules: fix badfilter collision handling

### DIFF
--- a/rules/match.go
+++ b/rules/match.go
@@ -274,12 +274,19 @@ func removeBadfilterRules(rules []*NetworkRule) (res []*NetworkRule) {
 
 // filterNegatedRules filters out rules that are negated by badfilter rules.
 func filterNegatedRules(badfilterRules, rules []*NetworkRule) (res []*NetworkRule) {
-	for _, badfilter := range badfilterRules {
-		for _, rule := range rules {
-			if !badfilter.negatesBadfilter(rule) && !rule.IsOptionEnabled(OptionBadfilter) {
-				res = append(res, rule)
+rulesLoop:
+	for _, rule := range rules {
+		if rule.IsOptionEnabled(OptionBadfilter) {
+			continue
+		}
+
+		for _, badfilter := range badfilterRules {
+			if badfilter.negatesBadfilter(rule) {
+				continue rulesLoop
 			}
 		}
+
+		res = append(res, rule)
 	}
 
 	return res

--- a/rules/match_internal_test.go
+++ b/rules/match_internal_test.go
@@ -8,6 +8,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFilterNegatedRules(t *testing.T) {
+	t.Parallel()
+
+	ruleA := newNetworkRule(t, "||a.example^")
+	ruleB := newNetworkRule(t, "||b.example^")
+	badfilterA := newNetworkRule(t, "||a.example^$badfilter")
+	badfilterB := newNetworkRule(t, "||b.example^$badfilter")
+	badfilterC := newNetworkRule(t, "||c.example^$badfilter")
+
+	testCases := []struct {
+		name           string
+		want           []*NetworkRule
+		badfilterRules []*NetworkRule
+		rules          []*NetworkRule
+	}{
+		{
+			name:           "matching_and_unrelated",
+			want:           nil,
+			badfilterRules: []*NetworkRule{badfilterA, badfilterB},
+			rules:          []*NetworkRule{ruleA, badfilterA, badfilterB},
+		},
+		{
+			name:           "several_unrelated",
+			want:           []*NetworkRule{ruleA},
+			badfilterRules: []*NetworkRule{badfilterB, badfilterC},
+			rules:          []*NetworkRule{ruleA, badfilterB, badfilterC},
+		},
+		{
+			name:           "existing_behavior",
+			want:           []*NetworkRule{ruleB},
+			badfilterRules: []*NetworkRule{badfilterA},
+			rules:          []*NetworkRule{ruleA, ruleB, badfilterA},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, filterNegatedRules(tc.badfilterRules, tc.rules))
+		})
+	}
+}
+
 func TestRemoveDNSRewriteRules(t *testing.T) {
 	t.Parallel()
 

--- a/rules/match_test.go
+++ b/rules/match_test.go
@@ -255,6 +255,41 @@ func TestGetDNSBasicRule(t *testing.T) {
 	}
 }
 
+func TestGetDNSBasicRule_badfilterCollisions(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		lines []string
+	}{
+		{
+			name: "colliding_rules",
+			lines: []string{
+				"||github.io^",
+				"||*.io^",
+				"||github.io^$badfilter",
+				"||*.io^$badfilter",
+			},
+		},
+		{
+			name: "unrelated_badfilter",
+			lines: []string{
+				"||blogspot.com^",
+				"||blogspot.com^$badfilter",
+				"||*.com^$badfilter",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Nil(t, rules.GetDNSBasicRule(newTestNetworkRules(t, tc.lines)))
+		})
+	}
+}
+
 // newTestNetworkRules returns network rules created from the given lines.
 func newTestNetworkRules(tb testing.TB, lines []string) (rs []*rules.NetworkRule) {
 	tb.Helper()


### PR DESCRIPTION
## Summary

- evaluate each ordinary rule once against all matching `$badfilter` rules;
- remove the ordinary rule when any `$badfilter` rule negates it;
- preserve ordinary-rule order without duplicating rules when several
  `$badfilter` candidates match the same request;
- add regression coverage for both the internal filtering helper and the
  public DNS-rule selection path.

The previous nested loop appended an ordinary rule once for every `$badfilter`
rule that did not negate it.  As a result, one matching `$badfilter` could
remove a rule while another non-negating candidate appended it again.  Several
non-negating candidates could also duplicate an ordinary rule in the result.

The new loop keeps the existing `O(rules * badfilters)` behavior, but makes the
intended invariant explicit: an ordinary rule is appended once only after all
candidate `$badfilter` rules have been checked.

## Validation

The new focused tests were first run against `dba702354cd6` and failed at the
expected assertions: a negated rule was returned and unrelated candidates
duplicated a rule.  They pass with this change.

- `go test -race -count=20 -run '^(TestFilterNegatedRules|TestGetDNSBasicRule_badfilterCollisions)$' ./rules`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `make go-os-check`
- `IGNORE_NON_REPRODUCIBLE=1 make go-check`

I also tested the two production-shaped cases through a disposable checkout of
current AdGuard Home master (`5f6cb57df9d5`).  Both reproduce with AdGuard
Home's pinned `urlfilter` v0.23.4.  With this checkout substituted locally, the
focused integration test passes 20 times under the race detector and
`go test -race -count=1 ./internal/filtering/...` passes.

### Upstream validation limitation

The unmodified `make go-deps go-check` currently stops in `govulncheck` on
upstream-pinned versions that this PR does not change:

- GO-2026-5970 in `golang.org/x/text` v0.38.0 (fixed in v0.39.0);
- GO-2026-5856 in the Go 1.26.4 standard library selected by the Makefile
  (fixed in Go 1.26.5).

The repository's documented `IGNORE_NON_REPRODUCIBLE=1` switch was used to run
the remaining checks, which passed.

Related to AdguardTeam/AdGuardHome#7873 and
AdguardTeam/AdGuardHome#7867.  Updating AdGuard Home's dependency requires a
separate urlfilter release and AdGuard Home change after this is merged.
