### PR TITLE
proxy: redact authentication credentials

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -51,7 +51,7 @@ func (c *Config) String() string {
 	str += fmt.Sprintf("Run as HTTPS proxy: %v\n", c.ProxyConfig.TLSConfig != nil)
 
 	if c.ProxyConfig.Username != "" {
-		str += fmt.Sprintf("Proxy auth: %s/%s\n", c.ProxyConfig.Username, c.ProxyConfig.Password)
+		str += "Proxy auth: enabled\n"
 	}
 	if c.ProxyConfig.APIHost != "" {
 		str += fmt.Sprintf("API host: %s\n", c.ProxyConfig.APIHost)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,0 +1,31 @@
+package proxy
+
+import (
+	"net"
+	"testing"
+
+	"github.com/AdguardTeam/gomitmproxy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigStringProxyAuth(t *testing.T) {
+	t.Parallel()
+
+	const (
+		username = "proxy-user"
+		password = "proxy-password"
+	)
+
+	conf := &Config{
+		ProxyConfig: gomitmproxy.Config{
+			ListenAddr: &net.TCPAddr{},
+			Username:   username,
+			Password:   password,
+		},
+	}
+
+	got := conf.String()
+	assert.Contains(t, got, "Proxy auth: enabled\n")
+	assert.NotContains(t, got, username)
+	assert.NotContains(t, got, password)
+}


### PR DESCRIPTION
## Summary

- Keep reporting whether proxy authentication is enabled.
- Stop including the proxy username and plaintext password in formatted
  configuration output.
- Add a regression test proving neither credential is exposed.

`proxy.New` logs `Config.String()` during startup, so formatting the credentials
there writes them to the configured log.  The replacement preserves the useful
authentication-status signal without including secrets.

This is a small dependency-hardening step for the explicit content-filtering
proxy discussed in AdguardTeam/AdGuardHome#1228.

## Validation

```text
PASS: go test -race -count=20 -run '^TestConfigStringProxyAuth$' ./proxy
PASS: go test -race -count=1 ./...
PASS: make go-os-check
PASS: make go-check IGNORE_NON_REPRODUCIBLE=1
PASS: gofumpt inspection
PASS: git diff --check
```

The documented `IGNORE_NON_REPRODUCIBLE` switch affects only the
`govulncheck` exit code.  The scan still reported two pre-existing findings in
the pinned dependencies/toolchain: GO-2026-5970 and GO-2026-5856.  All other
lint, vet, cross-platform, and race-enabled test gates passed.
